### PR TITLE
Prefix, comment additions, typos 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ source files that represent a single Go package.
 
 The `-type` flag accepts a comma-separated list of types so a single run can
 generate methods for multiple types. The default output file is t_jsonenums.go,
-where t is the lower-cased name of the first type listed. THe suffix can be
+where t is the lower-cased name of the first type listed. The suffix can be
 overridden with the `-suffix` flag.
 
 This is not an official Google product (experimental or otherwise), it is just code that happens to be owned by Google.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ source files that represent a single Go package.
 The `-type` flag accepts a comma-separated list of types so a single run can
 generate methods for multiple types. The default output file is t_jsonenums.go,
 where t is the lower-cased name of the first type listed. The suffix can be
-overridden with the `-suffix` flag.
+overridden with the `-suffix` flag and a prefix may be added with the `-prefix` 
+flag.
 
 This is not an official Google product (experimental or otherwise), it is just code that happens to be owned by Google.

--- a/jsonenums.go
+++ b/jsonenums.go
@@ -58,9 +58,10 @@
 // or a set of Go source files that represent a single Go package.
 //
 // The -type flag accepts a comma-separated list of types so a single run can
-// generate methods for multiple types. The default output file is t_string.go,
-// where t is the lower-cased name of the first type listed. The suffix can be
-// overridden with the -suffix flag.
+// generate methods for multiple types. The default output file is
+// t_jsonenums.go, where t is the lower-cased name of the first type listed.
+// The suffix can be overridden with the -suffix flag and a prefix may be added
+// with the -prefix flag.
 //
 package main
 
@@ -79,6 +80,7 @@ import (
 
 var (
 	typeNames    = flag.String("type", "", "comma-separated list of type names; must be set")
+	outputPrefix = flag.String("prefix", "", "prefix to be added to the output file")
 	outputSuffix = flag.String("suffix", "_jsonenums", "suffix to be added to the output file")
 )
 
@@ -97,7 +99,7 @@ func main() {
 		log.Fatalf("only one directory at a time")
 	}
 
-	pkg, err := parser.ParsePackage(dir, *outputSuffix+".go")
+	pkg, err := parser.ParsePackage(dir, *outputPrefix, *outputSuffix+".go")
 	if err != nil {
 		log.Fatalf("parsing package: %v", err)
 	}
@@ -134,7 +136,8 @@ func main() {
 			src = buf.Bytes()
 		}
 
-		output := strings.ToLower(typeName + *outputSuffix + ".go")
+		output := strings.ToLower(*outputPrefix + typeName +
+			*outputSuffix + ".go")
 		outputPath := filepath.Join(dir, output)
 		if err := ioutil.WriteFile(outputPath, src, 0644); err != nil {
 			log.Fatalf("writing output: %s", err)

--- a/jsonenums.go
+++ b/jsonenums.go
@@ -59,7 +59,7 @@
 //
 // The -type flag accepts a comma-separated list of types so a single run can
 // generate methods for multiple types. The default output file is t_string.go,
-// where t is the lower-cased name of the first type listed. THe suffix can be
+// where t is the lower-cased name of the first type listed. The suffix can be
 // overridden with the -suffix flag.
 //
 package main

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -30,7 +30,7 @@ type Package struct {
 }
 
 // ParsePackage parses the package in the given directory and returns it.
-func ParsePackage(directory string, skipSuffix string) (*Package, error) {
+func ParsePackage(directory, skipPrefix, skipSuffix string) (*Package, error) {
 	pkgDir, err := build.Default.ImportDir(directory, 0)
 	if err != nil {
 		return nil, fmt.Errorf("cannot process directory %s: %s", directory, err)
@@ -40,7 +40,8 @@ func ParsePackage(directory string, skipSuffix string) (*Package, error) {
 	fs := token.NewFileSet()
 	for _, name := range pkgDir.GoFiles {
 		if !strings.HasSuffix(name, ".go") ||
-			(skipSuffix != "" && strings.HasSuffix(name, skipSuffix)) {
+			(skipSuffix != "" && strings.HasPrefix(name, skipPrefix) &&
+				strings.HasSuffix(name, skipSuffix)) {
 			continue
 		}
 		if directory != "." {

--- a/server/server.go
+++ b/server/server.go
@@ -47,7 +47,7 @@ func generateHandler(w http.ResponseWriter, r *http.Request) error {
 	}
 	defer os.RemoveAll(dir)
 
-	pkg, err := parser.ParsePackage(dir, "")
+	pkg, err := parser.ParsePackage(dir, "", "")
 	if err != nil {
 		return fmt.Errorf("parse package: %v", err)
 	}

--- a/template.go
+++ b/template.go
@@ -42,7 +42,7 @@ func init() {
     }
 }
 
-// MarshalJSON returns *r as the JSON encoding of r.
+// MarshalJSON is generated; DO NOT EDIT
 func (r {{$typename}}) MarshalJSON() ([]byte, error) {
     if s, ok := interface{}(r).(fmt.Stringer); ok {
         return json.Marshal(s.String())
@@ -54,7 +54,7 @@ func (r {{$typename}}) MarshalJSON() ([]byte, error) {
     return json.Marshal(s)
 }
 
-// UnmarshalJSON sets *r to a copy of data.
+// UnmarshalJSON is generated; DO NOT EDIT
 func (r *{{$typename}}) UnmarshalJSON(data []byte) error {
     var s string
     if err := json.Unmarshal(data, &s); err != nil {

--- a/template.go
+++ b/template.go
@@ -42,6 +42,7 @@ func init() {
     }
 }
 
+// MarshalJSON returns *r as the JSON encoding of r.
 func (r {{$typename}}) MarshalJSON() ([]byte, error) {
     if s, ok := interface{}(r).(fmt.Stringer); ok {
         return json.Marshal(s.String())
@@ -53,6 +54,7 @@ func (r {{$typename}}) MarshalJSON() ([]byte, error) {
     return json.Marshal(s)
 }
 
+// UnmarshalJSON sets *r to a copy of data.
 func (r *{{$typename}}) UnmarshalJSON(data []byte) error {
     var s string
     if err := json.Unmarshal(data, &s); err != nil {


### PR DESCRIPTION
Prefixing the file path allows centralization of generated files and seems to me to be a natural option.  Golint is spoken of often enough in the community that satisfying it also seems to be a natural inclusion.  Minor typos fixed in and relevant information added to main package comment/readme.