### PR TITLE
Correct jsonenums go-generate example run

### DIFF
--- a/jsonenums.go
+++ b/jsonenums.go
@@ -5,7 +5,7 @@
 // JSONenums is a tool to automate the creation of methods that satisfy the
 // fmt.Stringer, json.Marshaler and json.Unmarshaler interfaces.
 // Given the name of a (signed or unsigned) integer type T that has constants
-// defined, stringer will create a new self-contained Go source file implementing
+// defined, jsonenums will create a new self-contained Go source file implementing
 //
 //  func (t T) String() string
 //  func (t T) MarshalJSON() ([]byte, error)
@@ -48,7 +48,7 @@
 //
 // Typically this process would be run using go generate, like this:
 //
-//	//go:generate stringer -type=Pill
+//	//go:generate jsonenums -type=Pill
 //
 // If multiple constants have the same value, the lexically first matching name will
 // be used (in the example, Acetaminophen will print as "Paracetamol").


### PR DESCRIPTION
Fixes a minor typo in the example.