### PR TITLE
Use static parsing instead of requiring a binary.

### DIFF
--- a/jsonenums.go
+++ b/jsonenums.go
@@ -75,7 +75,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/adfin/jsonenums/parser"
+	"github.com/campoy/jsonenums/parser"
 )
 
 var (
@@ -92,16 +92,16 @@ func main() {
 	types := strings.Split(*typeNames, ",")
 
 	// Only one directory at a time can be processed, and the default is ".".
-	in_dir := "."
+	inDir := "."
 	if args := flag.Args(); len(args) == 1 {
-		in_dir = args[0]
+		inDir = args[0]
 	} else if len(args) > 1 {
 		log.Fatalf("only one directory at a time")
 	}
-	dir, err := filepath.Abs(in_dir)
+	dir, err := filepath.Abs(inDir)
 	if err != nil {
 		log.Fatalf("Unable to determine absolute filepath for requested path %s: %v",
-			in_dir, err)
+			inDir, err)
 	}
 
 	pkg, err := parser.ParsePackage(dir)

--- a/jsonenums.go
+++ b/jsonenums.go
@@ -92,16 +92,16 @@ func main() {
 	types := strings.Split(*typeNames, ",")
 
 	// Only one directory at a time can be processed, and the default is ".".
-	inDir := "."
+	dir := "."
 	if args := flag.Args(); len(args) == 1 {
-		inDir = args[0]
+		dir = args[0]
 	} else if len(args) > 1 {
 		log.Fatalf("only one directory at a time")
 	}
-	dir, err := filepath.Abs(inDir)
+	dir, err := filepath.Abs(dir)
 	if err != nil {
-		log.Fatalf("Unable to determine absolute filepath for requested path %s: %v",
-			inDir, err)
+		log.Fatalf("unable to determine absolute filepath for requested path %s: %v",
+			dir, err)
 	}
 
 	pkg, err := parser.ParsePackage(dir)

--- a/jsonenums.go
+++ b/jsonenums.go
@@ -75,7 +75,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/thought-machine/jsonenums/parser"
+	"github.com/adfin/jsonenums/parser"
 )
 
 var (
@@ -92,14 +92,19 @@ func main() {
 	types := strings.Split(*typeNames, ",")
 
 	// Only one directory at a time can be processed, and the default is ".".
-	dir := "."
+	in_dir := "."
 	if args := flag.Args(); len(args) == 1 {
-		dir = args[0]
+		in_dir = args[0]
 	} else if len(args) > 1 {
 		log.Fatalf("only one directory at a time")
 	}
+	dir, err := filepath.Abs(in_dir)
+	if err != nil {
+		log.Fatalf("Unable to determine absolute filepath for requested path %s: %v",
+			in_dir, err)
+	}
 
-	pkg, err := parser.ParsePackage(dir, *outputPrefix, *outputSuffix+".go")
+	pkg, err := parser.ParsePackage(dir)
 	if err != nil {
 		log.Fatalf("parsing package: %v", err)
 	}

--- a/jsonenums.go
+++ b/jsonenums.go
@@ -75,7 +75,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/campoy/jsonenums/parser"
+	"github.com/thought-machine/jsonenums/parser"
 )
 
 var (

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -36,11 +36,11 @@ func ParsePackage(directory string) (*Package, error) {
 			build.Default.GOPATH, err)
 	}
 
-	loaderConf := loader.Config{TypeChecker: types.Config{FakeImportC: true}}
-	loaderConf.Import(relDir)
-	program, err := loaderConf.Load()
+	conf := loader.Config{TypeChecker: types.Config{FakeImportC: true}}
+	conf.Import(relDir)
+	program, err := conf.Load()
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't load package: %v", err)
+		return nil, fmt.Errorf("couldn't load package: %v", err)
 	}
 
 	pkgInfo := program.Package(relDir)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"go/constant"
-	"go/importer"
+	_ "go/importer"
 	"go/types"
 )
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"go/constant"
-	_ "go/importer"
+	"go/importer"
 	"go/types"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ import (
 
 	"go/format"
 
-	"github.com/thought-machine/jsonenums/parser"
+	"github.com/adfin/jsonenums/parser"
 )
 
 func init() {

--- a/server/server.go
+++ b/server/server.go
@@ -47,7 +47,7 @@ func generateHandler(w http.ResponseWriter, r *http.Request) error {
 	}
 	defer os.RemoveAll(dir)
 
-	pkg, err := parser.ParsePackage(dir, "", "")
+	pkg, err := parser.ParsePackage(dir)
 	if err != nil {
 		return fmt.Errorf("parse package: %v", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ import (
 
 	"go/format"
 
-	"github.com/adfin/jsonenums/parser"
+	"github.com/campoy/jsonenums/parser"
 )
 
 func init() {

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ import (
 
 	"go/format"
 
-	"github.com/campoy/jsonenums/parser"
+	"github.com/thought-machine/jsonenums/parser"
 )
 
 func init() {


### PR DESCRIPTION
Using go/parser requires a built binary of the code to be enum'ed to
exist. This leads to two problems:

  1. The binary may be very out of date with the code, for example, when pulling into an existing repo that was last built locally some time ago, running jsonenums on newly added files will fail;
  2. If the binary has never been built, but the code already expects the output of jsonenums, it will be impossible to generate the enums, making it impossible to build the binary.

In response to a similar issue, Alan Donovan of the Go team suggested
that instead generating tools should be using (the not-yet stable)
x/tools/go/loader package to parse the actual Go code itself rather than
the compilation output: golang/go#11415

This change uses the suggested approach to break the bootstrapping
dependency cycle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/campoy/jsonenums/12)
<!-- Reviewable:end -->
