### PR TITLE
Allow setting a custom output file which will contain all types, fixes #9

### DIFF
--- a/jsonenums.go
+++ b/jsonenums.go
@@ -91,7 +91,8 @@ var (
 	typeNames    = flag.String("type", "", "comma-separated list of type names; must be set")
 	outputPrefix = flag.String("prefix", "", "prefix to be added to the output file")
 	outputSuffix = flag.String("suffix", "_jsonenums", "suffix to be added to the output file")
-	outputFile   = flag.String("file", "", "Specify the exact filename to output with.  Will ignore output prefix/suffix values.")
+	outputFile   = flag.String("file", "", "Specify the exact filename to output with.  "+
+		"Will ignore output prefix/suffix values.  This option should be used if multiple types are set")
 )
 
 func main() {

--- a/jsonenums.go
+++ b/jsonenums.go
@@ -91,6 +91,7 @@ var (
 	typeNames    = flag.String("type", "", "comma-separated list of type names; must be set")
 	outputPrefix = flag.String("prefix", "", "prefix to be added to the output file")
 	outputSuffix = flag.String("suffix", "_jsonenums", "suffix to be added to the output file")
+	outputFile   = flag.String("file", "", "Specify the exact filename to output with.  Will ignore output prefix/suffix values.")
 )
 
 func main() {
@@ -152,6 +153,10 @@ func main() {
 
 		output := strings.ToLower(*outputPrefix + typeName +
 			*outputSuffix + ".go")
+		if *outputFile != "" {
+			// This will make sure that .go is at the end whether or not a user specifies it
+			output = strings.TrimSuffix(*outputFile, ".go") + ".go"
+		}
 		outputPath := filepath.Join(dir, output)
 		if err := ioutil.WriteFile(outputPath, src, 0644); err != nil {
 			log.Fatalf("writing output: %s", err)


### PR DESCRIPTION
Adding a new flag to set a custom output file will allow you to set a single file for all the code to go into which essentially works around the problem in issue #9, one other possible solution is to clear the buffer at the end of the loop but it all depends on how you want this program to work (I can see reasons both individual files or a file for each one).