### PR TITLE
Address the issue when the enum value is passed as null

### DIFF
--- a/example/shirtsize_jsonenums.go
+++ b/example/shirtsize_jsonenums.go
@@ -41,6 +41,7 @@ func init() {
 	}
 }
 
+// MarshalJSON is generated so ShirtSize satisfies json.Marshaler.
 func (r ShirtSize) MarshalJSON() ([]byte, error) {
 	if s, ok := interface{}(r).(fmt.Stringer); ok {
 		return json.Marshal(s.String())
@@ -52,7 +53,11 @@ func (r ShirtSize) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+// UnmarshalJSON is generated so ShirtSize satisfies json.Unmarshaler.
 func (r *ShirtSize) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return fmt.Errorf("ShirtSize should be a string, got %s", data)

--- a/example/weekday_jsonenums.go
+++ b/example/weekday_jsonenums.go
@@ -44,6 +44,7 @@ func init() {
 	}
 }
 
+// MarshalJSON is generated so WeekDay satisfies json.Marshaler.
 func (r WeekDay) MarshalJSON() ([]byte, error) {
 	if s, ok := interface{}(r).(fmt.Stringer); ok {
 		return json.Marshal(s.String())
@@ -55,7 +56,11 @@ func (r WeekDay) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+// UnmarshalJSON is generated so WeekDay satisfies json.Unmarshaler.
 func (r *WeekDay) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return fmt.Errorf("WeekDay should be a string, got %s", data)

--- a/template.go
+++ b/template.go
@@ -65,6 +65,9 @@ func (r {{$typename}}) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is generated so {{$typename}} satisfies json.Unmarshaler.
 func (r *{{$typename}}) UnmarshalJSON(data []byte) error {
+    if string(data) == "null" {
+        return nil
+    }
     var s string
     if err := json.Unmarshal(data, &s); err != nil {
         return fmt.Errorf("{{$typename}} should be a string, got %s", data)


### PR DESCRIPTION
While working with `jsonenums` I have encountered something I presume to be a potential issue when dealing with `null` values.

Provided JSON payload:

```JSON
{"type":null}
```

And enum type:

```go
package thetype

type Type int

//go:generate jsonenums -type=Type

const (
	_ Type = iota
	A
        B
)
```

In order to unmarshal payload into `Type`, `json.Unmarshal` is used like:

```go
func (r *State) UnmarshalJSON(data []byte) error {
  var s string
  if err := json.Unmarshal(data, &s); err != nil {
    return fmt.Errorf("Type should be a string, got %s", data)
  }
  // code ommited
```

Since `json.Unmarshal` implements `UnmarshalJSON([]byte("null"))` as a no-op, `s` is not mutated and it remains at zero value. That, in the following lines will:

```go
v, ok := _Type[s]
if !ok {
  return fmt.Errorf("invalid Type %q", s)
}
```

result in `error` being returned as empty string does not map to any `Type`.

This PR offers a potential way to deal with this problem by checking if `data` is actually `null` prior to using `json.Unmarshal`.
